### PR TITLE
Vercelのプレビューデプロイをdevelopブランチだけにするスクリプトを追加

### DIFF
--- a/scripts/vercel-ignore-build-step.sh
+++ b/scripts/vercel-ignore-build-step.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
+
+# developブランチにpushされた際のみpreview deployを行う
+# 参考: https://zenn.dev/catnose99/articles/b37104fc7ef214
+if [[ "$VERCEL_GIT_COMMIT_REF" == "develop" ]] ; then
+  # Proceed with the build
+  echo "✅ - Build can proceed"
+  exit 1;
+
+else
+  # Don't build
+  echo "🛑 - Build cancelled"
+  exit 0;
+fi


### PR DESCRIPTION
## 内容
- Vercelのプレビューデプロイをdevelopブランチだけにするスクリプトを追加

## Issue
#30 

## 備考
- Vercel側にも設定済み

## 参考
- https://zenn.dev/catnose99/articles/b37104fc7ef214
