### PR TITLE
記事一覧の並び順を降順にする

### DIFF
--- a/src/components/pages/top/Top.tsx
+++ b/src/components/pages/top/Top.tsx
@@ -7,6 +7,9 @@ type Props = {
 };
 
 export const Top = ({ articles }: Props) => {
+  const copyArticles = [...articles];
+  const sortedArticles = copyArticles.reverse();
+
   return (
     <BaseLayout>
       <div className="mx-auto w-full max-w-[1280px]">
@@ -16,7 +19,7 @@ export const Top = ({ articles }: Props) => {
               Articles
             </h2>
             <ol className="grid grid-cols-1 gap-y-[30px] sm:grid-cols-2 sm:gap-x-[30px] md:grid-cols-3">
-              {articles.map((article, i) => {
+              {sortedArticles.map((article, i) => {
                 return (
                   <li key={i}>
                     <Card meta={article} />


### PR DESCRIPTION
## 内容
- 記事一覧の並び順を降順にする

## Issue
#24 

## 備考
- 現状getStaticPropsで取得した記事一覧がid順で返ってくるので単純に逆順にした。
