### PR TITLE
記事一覧のカードの高さを揃える

### DIFF
--- a/src/components/ui/Card/Card.tsx
+++ b/src/components/ui/Card/Card.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 export const Card = ({ meta }: Props) => {
   return (
-    <div className="p-5 bg-white rounded-md shadow-md">
+    <div className="flex flex-col p-5 h-full bg-white rounded-md shadow-md">
       <Link href={`/article/${meta.id}`}>
         <a className="block mb-4">
           <Img
@@ -32,7 +32,7 @@ export const Card = ({ meta }: Props) => {
       <Link href={`/article/${meta.id}`}>
         <a className="table mb-2.5 font-bold tracking-wider">{meta.title}</a>
       </Link>
-      <CategoryLabel categoryName={meta.category} className="text-xs" />
+      <CategoryLabel categoryName={meta.category} className="mt-auto text-xs" />
     </div>
   );
 };


### PR DESCRIPTION
## 内容
- 記事一覧のカードの高さを揃える

## Issue
#25 

## 備考
- 修正後
<img width="792" alt="スクリーンショット 2022-03-21 9 09 07" src="https://user-images.githubusercontent.com/56911907/159191915-abc3fa47-2609-4b53-8c66-0c5dad018308.png">