### PR TITLE
SNSシェアボタンのクリック時にGAにイベントを送信

### DIFF
--- a/src/components/ui/LINEShare/LINEShare.tsx
+++ b/src/components/ui/LINEShare/LINEShare.tsx
@@ -1,5 +1,6 @@
 import { ExternalLink } from "@/components/functionals/ExternalLink";
 import { LINEIcon } from "@/components/icons/LINE";
+import { EVENT_ACTION, EVENT_CATEGORY, sendEvent } from "@/libs/gtag";
 import { getLINEShareURL } from "@/utils/url";
 
 type Props = {
@@ -14,6 +15,13 @@ export const LINEShare = ({ path, title, className = "" }: Props) => {
     <ExternalLink
       href={shareUrl}
       title="LINEでシェア"
+      onClick={() =>
+        sendEvent({
+          action: EVENT_ACTION.CLICK,
+          category: EVENT_CATEGORY.SNS_SHARE_TWITTER,
+          label: path.slice(1),
+        })
+      }
       className={`hover:opacity-70 focus-visible:ring-blue-600 table ${className}`}
     >
       <LINEIcon size={28} />

--- a/src/components/ui/TwitterShare/TwitterShare.tsx
+++ b/src/components/ui/TwitterShare/TwitterShare.tsx
@@ -1,5 +1,6 @@
 import { ExternalLink } from "@/components/functionals/ExternalLink";
 import { TwitterIcon } from "@/components/icons/Twitter";
+import { EVENT_ACTION, EVENT_CATEGORY, sendEvent } from "@/libs/gtag";
 
 import { getTwitterShareURL } from "@/utils/url";
 
@@ -15,6 +16,13 @@ export const TwitterShare = ({ path, title, className = "" }: Props) => {
     <ExternalLink
       href={shareUrl}
       title="Twitterでシェア"
+      onClick={() =>
+        sendEvent({
+          action: EVENT_ACTION.CLICK,
+          category: EVENT_CATEGORY.SNS_SHARE_TWITTER,
+          label: path.slice(1),
+        })
+      }
       className={`hover:opacity-70 focus-visible:ring-blue-600 table ${className}`}
     >
       <TwitterIcon size={28} />

--- a/src/hooks/use-page-view/use-page-view.ts
+++ b/src/hooks/use-page-view/use-page-view.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useRouter } from "next/router";
 
-import { existsGaId, pageview } from "@/libs/gtag";
+import { existsGaId, sendPageview } from "@/libs/gtag";
 
 export default function usePageView() {
   const router = useRouter();
@@ -12,7 +12,7 @@ export default function usePageView() {
     }
 
     const handleRouteChange = (path: string) => {
-      pageview(path);
+      sendPageview(path);
     };
 
     router.events.on("routeChangeComplete", handleRouteChange);

--- a/src/libs/gtag.ts
+++ b/src/libs/gtag.ts
@@ -1,26 +1,35 @@
 export const GA_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID || "";
 
+export const EVENT_ACTION = {
+  CLICK: "click",
+} as const;
+
+export const EVENT_CATEGORY = {
+  SNS_SHARE_TWITTER: "sns_share_twitter",
+  SNS_SHARE_LINE: "sns_share_line",
+} as const;
+
 // IDが取得できない場合を想定する
 export const existsGaId = GA_ID !== "";
 
 // PVを測定する
-export const pageview = (path: string) => {
+export const sendPageview = (path: string) => {
   window.gtag("config", GA_ID, {
     page_path: path,
   });
 };
 
 // GAイベントを発火させる
-export const event = ({
+export const sendEvent = ({
   action,
   category,
   label,
-  value = "",
+  value = 0,
 }: {
   action: string;
   category: string;
   label: string;
-  value: string;
+  value?: number;
 }) => {
   if (!existsGaId) {
     return;


### PR DESCRIPTION
## 内容
- SNSシェアボタンのクリック時にGAにイベントを送信

## Issue
#28 

## 備考
- labelは`article/1`のようにシェアするページがわかるようにした
- valueはとりあえず0にした
- event_paramsに関してはもう少し柔軟に設定できるかもしれない
- ローカルでの検証が難しいため動作検証はpreviewで行う

## 参考
- https://developers.google.com/tag-platform/gtagjs/reference?hl=ja#event
- https://anagrams.jp/blog/how-to-set-up-and-use-event-tracking-in-google-analytics/#onClickgtagjs
