### PR TITLE
CIでStorybookの起動テストを行う

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+on:
+  pull_request:
+    branches:
+      - develop
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install packages
+        run: npm ci
+      - name: Storybook Startup Test
+        run: npm run storybook-startup-test
+      - name: Next App Build Test
+        run: npx next build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,12 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - uses: actions/cache@v3
         with:
-          path: ~/.npm
-          key: node-${{ hashFiles('**/package-lock.json') }}
+          path: |
+            ~/.npm
+            ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
           restore-keys: |
-            node-
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
       - name: Install packages
         run: npm ci
       - name: Storybook Startup Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Set Env
+        run: |
+          echo NODE_VERSION=$(cat .tool-versions | sed -e "s/nodejs //g") >> $GITHUB_ENV
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            node-
       - name: Install packages
         run: npm ci
       - name: Storybook Startup Test

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "storybook": "start-storybook -p 6006",
+    "storybook-startup-test": "start-storybook --smoke-test --ci --quiet",
     "build-storybook": "build-storybook"
   },
   "dependencies": {


### PR DESCRIPTION
## 内容
- CIでStorybookの起動テストを行う

## Issue
#48 

## 備考
- Storybookの起動テストと合わせてNext.jsのビルドのテストも追加した

## 参考
- https://storybook.js.org/docs/react/api/cli-options
- GitHub Actionsでnode_modulesとNext.jsのビルドファイルをキャッシュする
https://nextjs.org/docs/messages/no-cache#github-actions
- GitHub Actionsでシェルスクリプトを使って環境変数を設定する場合のやり方
https://zenn.dev/kyome/articles/a89fd954c5936f